### PR TITLE
Add configuration support and Let's Encrypt HTTPS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,16 +36,21 @@ All fields are optional. Place the file next to the binary (or mount it into the
 | Key                  | Type   | Default                  | Description                              |
 |----------------------|--------|--------------------------|------------------------------------------|
 | `port`               | int    | `80`                     | HTTP listen port                         |
-| `content_path`       | string | `/var/semdgo/content`    | Directory containing markdown files      |
-| `content_entrypoint` | string | `README.md`              | File served at `/`                       |
+| `content_path`       | string | `/var/semdgo/content`    | Path to content dir or a specific `.md` file |
 | `letsencrypt.enabled`| bool   | `false`                  | Enable automatic HTTPS via Let's Encrypt |
 | `letsencrypt.domain` | string | —                        | Required when `enabled` is true          |
 | `letsencrypt.email`  | string | —                        | Optional, for cert expiry notifications  |
 
+`content_path` behaviour:
+- **Directory** → serves files from it, entry point is `README.md`
+- **`.md` file** → serves files from its parent dir, that file is the entry point
+
 Startup validation (via `config.Validate`) will fatal if:
-- `content_path` does not exist or is not a directory
-- `content_path/content_entrypoint` does not exist
+- `content_path` does not exist
+- the resolved entry point file does not exist
 - `letsencrypt.enabled` is true but `letsencrypt.domain` is empty
+
+`Validate` also sets the unexported-facing fields `cfg.ContentDir` and `cfg.ContentEntrypoint` which are consumed by the handler.
 
 ## Key Implementation Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+## Project Overview
+
+SEMDGO is a lightweight markdown file server written in Go. It serves `.md` files from a configured content directory, rendering them to HTML via a built-in template. Non-markdown files (images, etc.) are served as static assets.
+
+## Repository Structure
+
+```
+cmd/server/main.go              — entry point, wires config → handler, starts HTTP/HTTPS
+internal/config/config.go       — Config struct, Load() from semdgo.json, Validate()
+internal/handler/handler.go     — New(contentPath, entrypoint) returns http.HandlerFunc
+internal/renderer/markdown.go   — MDtoHTML() wraps gomarkdown
+internal/utils/path.go          — ClickedHyperlink() maps request URL to filesystem path
+templates/200                   — Go HTML template for rendered markdown pages
+Dockerfile                      — multi-stage build; copies binary + templates into alpine
+```
+
+## Build & Run
+
+```bash
+# build
+go build -o ./dist/semdgo ./cmd/server
+
+# run (reads semdgo.json from cwd, templates/ must be present)
+./dist/semdgo
+
+# or run directly
+go run ./cmd/server
+```
+
+## Configuration (`semdgo.json`)
+
+All fields are optional. Place the file next to the binary (or mount it into the container).
+
+| Key                  | Type   | Default                  | Description                              |
+|----------------------|--------|--------------------------|------------------------------------------|
+| `port`               | int    | `80`                     | HTTP listen port                         |
+| `content_path`       | string | `/var/semdgo/content`    | Directory containing markdown files      |
+| `content_entrypoint` | string | `README.md`              | File served at `/`                       |
+| `letsencrypt.enabled`| bool   | `false`                  | Enable automatic HTTPS via Let's Encrypt |
+| `letsencrypt.domain` | string | —                        | Required when `enabled` is true          |
+| `letsencrypt.email`  | string | —                        | Optional, for cert expiry notifications  |
+
+Startup validation (via `config.Validate`) will fatal if:
+- `content_path` does not exist or is not a directory
+- `content_path/content_entrypoint` does not exist
+- `letsencrypt.enabled` is true but `letsencrypt.domain` is empty
+
+## Key Implementation Notes
+
+- **Template location**: `templates/200` is loaded relative to the working directory at request time via `template.ParseFiles`. When running locally the binary must be executed from the repo root (or wherever `templates/` lives). The Dockerfile copies `templates/` to `/templates` at the container root and runs the binary from `/`.
+- **Static assets**: any request for a path not ending in `.md` is passed to `http.ServeFile`, so images and other files linked from markdown are served directly from `content_path`.
+- **Let's Encrypt**: certs are cached at `/var/semdgo/certs`. HTTP on `:80` is kept alive for the ACME HTTP-01 challenge and redirects all other traffic to HTTPS on `:443`.
+
+## Docker
+
+```bash
+# single-arch
+docker build -t shafinhasnat/semdgo .
+
+# multi-arch push
+docker buildx build \
+  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+  -t shafinhasnat/semdgo --push .
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 
 ## Technical Specifications
 
-- **Content Directory**: `/var/semdgo/content/` (configurable via `content_path`)
-- **Default Entry Point**: `README.md` (configurable via `content_entrypoint`)
+- **Content Path**: `/var/semdgo/content/` (configurable via `content_path`)
+- **Default Entry Point**: `README.md`
 - **Default Port**: 80
 - **Architecture Support**: Multi-architecture (amd64, arm64, arm/v7)
 - **Runtime**: Containerized (Docker)
@@ -18,25 +18,25 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 
 SEMDGO can be configured by placing a `semdgo.json` file in the working directory (next to the binary or mounted into the container).
 
-### Custom Content Path
+### Content Path
 
+`content_path` controls both where content is served from and which file is the entry point at `/`.
+
+**Point to a directory** — serves all files from that directory, uses `README.md` as the entry point:
 ```json
 {
   "content_path": "/path/to/your/content"
 }
 ```
 
-The default is `/var/semdgo/content`.
-
-### Custom Entry Point
-
+**Point to a specific `.md` file** — serves files from its parent directory, uses that file as the entry point:
 ```json
 {
-  "content_entrypoint": "index.md"
+  "content_path": "/path/to/your/content/index.md"
 }
 ```
 
-The default is `README.md`. This file must exist inside `content_path` — SEMDGO validates this on startup and will refuse to start if it is missing.
+The default is `/var/semdgo/content` (directory). SEMDGO validates the path and entry point on startup and will refuse to start if either is missing.
 
 ### Custom Port
 
@@ -135,14 +135,19 @@ cd semdgo
 go mod download
 ```
 
-3. **Prepare content**: By default SEMDGO serves files from `/var/semdgo/content/`. You can either create that directory or point to any local path via `semdgo.json`:
+3. **Prepare content**: Point `content_path` at a directory (needs a `README.md` inside) or directly at a `.md` file:
 ```json
 {
   "content_path": "/home/you/my-docs",
   "port": 8080
 }
 ```
-The directory must contain a `README.md` as the entry point.
+```json
+{
+  "content_path": "/home/you/my-docs/index.md",
+  "port": 8080
+}
+```
 
 4. **Run directly with Go**:
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,9 +10,41 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 
 - **Content Directory**: `/var/semdgo/content/`
 - **Default Entry Point**: `README.md`
-- **Port**: 80
+- **Default Port**: 80
 - **Architecture Support**: Multi-architecture (amd64, arm64, arm/v7)
 - **Runtime**: Containerized (Docker)
+
+## Configuration
+
+SEMDGO can be configured by placing a `semdgo.json` file in the working directory (next to the binary or mounted into the container).
+
+### Custom Port
+
+```json
+{
+  "port": 8080
+}
+```
+
+### Automatic HTTPS with Let's Encrypt
+
+SEMDGO supports automatic TLS certificate provisioning via Let's Encrypt — no manual certificate management required. When enabled, HTTP traffic on port 80 is automatically redirected to HTTPS on port 443.
+
+> **Requirements**: your domain must point to the server and ports 80 and 443 must be publicly reachable.
+
+```json
+{
+  "letsencrypt": {
+    "enabled": true,
+    "domain": "docs.example.com",
+    "email": "you@example.com"
+  }
+}
+```
+
+Certificates are cached at `/var/semdgo/certs` and auto-renewed before expiry.
+
+If no `semdgo.json` is present, SEMDGO defaults to port 80 over plain HTTP.
 
 ## Quick Start
 
@@ -26,6 +58,21 @@ CMD ["./semdgo"]
 ```
 
 2. **Docker Compose Deployment**:
+
+Plain HTTP on a custom port:
+```yaml
+services:
+  semdgo:
+    image: shafinhasnat/semdgo
+    container_name: semdgo
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./README.md:/var/semdgo/content/README.md
+      - ./semdgo.json:/semdgo.json
+```
+
+With Let's Encrypt HTTPS:
 ```yaml
 services:
   semdgo:
@@ -33,8 +80,14 @@ services:
     container_name: semdgo
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./README.md:/var/semdgo/content/README.md
+      - ./semdgo.json:/semdgo.json
+      - semdgo_certs:/var/semdgo/certs
+
+volumes:
+  semdgo_certs:
 ```
 
 Deploy using:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 
 ## Technical Specifications
 
-- **Content Directory**: `/var/semdgo/content/`
+- **Content Directory**: `/var/semdgo/content/` (configurable via `content_path`)
 - **Default Entry Point**: `README.md`
 - **Default Port**: 80
 - **Architecture Support**: Multi-architecture (amd64, arm64, arm/v7)
@@ -17,6 +17,16 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 ## Configuration
 
 SEMDGO can be configured by placing a `semdgo.json` file in the working directory (next to the binary or mounted into the container).
+
+### Custom Content Path
+
+```json
+{
+  "content_path": "/path/to/your/content"
+}
+```
+
+The default is `/var/semdgo/content`. The directory must contain a `README.md` as the entry point.
 
 ### Custom Port
 
@@ -115,11 +125,14 @@ cd semdgo
 go mod download
 ```
 
-3. **Prepare content**: SEMDGO serves files from `/var/semdgo/content/`. Create the directory and add markdown files, or symlink your own:
-```bash
-sudo mkdir -p /var/semdgo/content/
-sudo cp README.md /var/semdgo/content/
+3. **Prepare content**: By default SEMDGO serves files from `/var/semdgo/content/`. You can either create that directory or point to any local path via `semdgo.json`:
+```json
+{
+  "content_path": "/home/you/my-docs",
+  "port": 8080
+}
 ```
+The directory must contain a `README.md` as the entry point.
 
 4. **Run directly with Go**:
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SEMDGO is designed for developers and content creators who need a simple yet pow
 ## Technical Specifications
 
 - **Content Directory**: `/var/semdgo/content/` (configurable via `content_path`)
-- **Default Entry Point**: `README.md`
+- **Default Entry Point**: `README.md` (configurable via `content_entrypoint`)
 - **Default Port**: 80
 - **Architecture Support**: Multi-architecture (amd64, arm64, arm/v7)
 - **Runtime**: Containerized (Docker)
@@ -26,7 +26,17 @@ SEMDGO can be configured by placing a `semdgo.json` file in the working director
 }
 ```
 
-The default is `/var/semdgo/content`. The directory must contain a `README.md` as the entry point.
+The default is `/var/semdgo/content`.
+
+### Custom Entry Point
+
+```json
+{
+  "content_entrypoint": "index.md"
+}
+```
+
+The default is `README.md`. This file must exist inside `content_path` — SEMDGO validates this on startup and will refuse to start if it is missing.
 
 ### Custom Port
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,58 @@ Deploy using:
 docker-compose up -d
 ```
 
+## Running Locally
+
+### Prerequisites
+
+- Go 1.24+
+- Git
+
+### Steps
+
+1. **Clone the repository**:
+```bash
+git clone https://github.com/shafinhasnat/semdgo.git
+cd semdgo
+```
+
+2. **Install dependencies**:
+```bash
+go mod download
+```
+
+3. **Prepare content**: SEMDGO serves files from `/var/semdgo/content/`. Create the directory and add markdown files, or symlink your own:
+```bash
+sudo mkdir -p /var/semdgo/content/
+sudo cp README.md /var/semdgo/content/
+```
+
+4. **Run directly with Go**:
+```bash
+go run ./cmd/server
+```
+
+Or build first, then run:
+```bash
+go build -o ./dist/semdgo ./cmd/server
+./dist/semdgo
+```
+
+5. **Open in browser**: Navigate to `http://localhost` (or the port set in `semdgo.json`).
+
+To use a custom port without root privileges, create a `semdgo.json` in the working directory:
+```json
+{
+  "port": 8080
+}
+```
+Then run `./dist/semdgo` and open `http://localhost:8080`.
+
 ## Building from Source
 
 ### Local Build
 ```bash
-go build ./cmd/server -o ./dist/semdgo
+go build -o ./dist/semdgo ./cmd/server
 ```
 
 ### Multi-architecture Docker Build

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,13 +17,13 @@ func main() {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
-	http.HandleFunc("/", handler.New(cfg.ContentPath))
+	if err := config.Validate(cfg); err != nil {
+		log.Fatalf("Invalid configuration: %v", err)
+	}
+
+	http.HandleFunc("/", handler.New(cfg.ContentPath, cfg.ContentEntrypoint))
 
 	if cfg.LetsEncrypt.Enabled {
-		if cfg.LetsEncrypt.Domain == "" {
-			log.Fatal("letsencrypt.domain must be set when letsencrypt.enabled is true")
-		}
-
 		m := &autocert.Manager{
 			Prompt:     autocert.AcceptTOS,
 			HostPolicy: autocert.HostWhitelist(cfg.LetsEncrypt.Domain),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
-	http.HandleFunc("/", handler.Handle)
+	http.HandleFunc("/", handler.New(cfg.ContentPath))
 
 	if cfg.LetsEncrypt.Enabled {
 		if cfg.LetsEncrypt.Domain == "" {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,14 +1,55 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/shafinhasnat/semdgo/internal/config"
 	"github.com/shafinhasnat/semdgo/internal/handler"
 )
 
 func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
 	http.HandleFunc("/", handler.Handle)
-	log.Println("Starting server on port 80")
-	http.ListenAndServe(":80", nil)
+
+	if cfg.LetsEncrypt.Enabled {
+		if cfg.LetsEncrypt.Domain == "" {
+			log.Fatal("letsencrypt.domain must be set when letsencrypt.enabled is true")
+		}
+
+		m := &autocert.Manager{
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(cfg.LetsEncrypt.Domain),
+			Cache:      autocert.DirCache("/var/semdgo/certs"),
+		}
+		if cfg.LetsEncrypt.Email != "" {
+			m.Email = cfg.LetsEncrypt.Email
+		}
+
+		// HTTP -> HTTPS redirect
+		go func() {
+			log.Println("Starting HTTP redirect server on :80")
+			if err := http.ListenAndServe(":80", m.HTTPHandler(nil)); err != nil {
+				log.Printf("HTTP redirect server error: %v", err)
+			}
+		}()
+
+		log.Printf("Starting HTTPS server on :443 for domain %s", cfg.LetsEncrypt.Domain)
+		server := &http.Server{
+			Addr:      ":443",
+			TLSConfig: m.TLSConfig(),
+		}
+		log.Fatal(server.ListenAndServeTLS("", ""))
+	} else {
+		addr := fmt.Sprintf(":%d", cfg.Port)
+		log.Printf("Starting server on port %d", cfg.Port)
+		log.Fatal(http.ListenAndServe(addr, nil))
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatalf("Invalid configuration: %v", err)
 	}
 
-	http.HandleFunc("/", handler.New(cfg.ContentPath, cfg.ContentEntrypoint))
+	http.HandleFunc("/", handler.New(cfg.ContentDir, cfg.ContentEntrypoint))
 
 	if cfg.LetsEncrypt.Enabled {
 		m := &autocert.Manager{

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module github.com/shafinhasnat/semdgo
 
-go 1.23.4
+go 1.24.0
+
+toolchain go1.24.7
 
 require github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
+
+require (
+	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
 github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b h1:EY/KpStFl60qA17CptGXhwfZ+k1sFNJIUNR8DdbcuUk=
 github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
+golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
+golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
+golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
+golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type LetsEncryptConfig struct {
@@ -12,15 +14,17 @@ type LetsEncryptConfig struct {
 }
 
 type Config struct {
-	Port        int               `json:"port"`
-	ContentPath string            `json:"content_path"`
-	LetsEncrypt LetsEncryptConfig `json:"letsencrypt"`
+	Port             int               `json:"port"`
+	ContentPath      string            `json:"content_path"`
+	ContentEntrypoint string           `json:"content_entrypoint"`
+	LetsEncrypt      LetsEncryptConfig `json:"letsencrypt"`
 }
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		Port:        80,
-		ContentPath: "/var/semdgo/content",
+		Port:              80,
+		ContentPath:       "/var/semdgo/content",
+		ContentEntrypoint: "README.md",
 	}
 
 	data, err := os.ReadFile("semdgo.json")
@@ -32,7 +36,7 @@ func Load() (*Config, error) {
 	}
 
 	if err := json.Unmarshal(data, cfg); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid semdgo.json: %w", err)
 	}
 
 	if cfg.Port == 0 {
@@ -41,6 +45,36 @@ func Load() (*Config, error) {
 	if cfg.ContentPath == "" {
 		cfg.ContentPath = "/var/semdgo/content"
 	}
+	if cfg.ContentEntrypoint == "" {
+		cfg.ContentEntrypoint = "README.md"
+	}
 
 	return cfg, nil
+}
+
+func Validate(cfg *Config) error {
+	info, err := os.Stat(cfg.ContentPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("content_path %q does not exist", cfg.ContentPath)
+		}
+		return fmt.Errorf("content_path %q: %w", cfg.ContentPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("content_path %q is not a directory", cfg.ContentPath)
+	}
+
+	entrypoint := filepath.Join(cfg.ContentPath, cfg.ContentEntrypoint)
+	if _, err := os.Stat(entrypoint); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("content_entrypoint %q does not exist in %q", cfg.ContentEntrypoint, cfg.ContentPath)
+		}
+		return fmt.Errorf("content_entrypoint %q: %w", entrypoint, err)
+	}
+
+	if cfg.LetsEncrypt.Enabled && cfg.LetsEncrypt.Domain == "" {
+		return fmt.Errorf("letsencrypt.domain must be set when letsencrypt.enabled is true")
+	}
+
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type LetsEncryptConfig struct {
+	Enabled bool   `json:"enabled"`
+	Domain  string `json:"domain"`
+	Email   string `json:"email"`
+}
+
+type Config struct {
+	Port        int               `json:"port"`
+	LetsEncrypt LetsEncryptConfig `json:"letsencrypt"`
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{
+		Port: 80,
+	}
+
+	data, err := os.ReadFile("semdgo.json")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	if cfg.Port == 0 {
+		cfg.Port = 80
+	}
+
+	return cfg, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,14 @@ type LetsEncryptConfig struct {
 
 type Config struct {
 	Port        int               `json:"port"`
+	ContentPath string            `json:"content_path"`
 	LetsEncrypt LetsEncryptConfig `json:"letsencrypt"`
 }
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		Port: 80,
+		Port:        80,
+		ContentPath: "/var/semdgo/content",
 	}
 
 	data, err := os.ReadFile("semdgo.json")
@@ -35,6 +37,9 @@ func Load() (*Config, error) {
 
 	if cfg.Port == 0 {
 		cfg.Port = 80
+	}
+	if cfg.ContentPath == "" {
+		cfg.ContentPath = "/var/semdgo/content"
 	}
 
 	return cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,17 +14,19 @@ type LetsEncryptConfig struct {
 }
 
 type Config struct {
-	Port             int               `json:"port"`
-	ContentPath      string            `json:"content_path"`
-	ContentEntrypoint string           `json:"content_entrypoint"`
-	LetsEncrypt      LetsEncryptConfig `json:"letsencrypt"`
+	Port        int               `json:"port"`
+	ContentPath string            `json:"content_path"`
+	LetsEncrypt LetsEncryptConfig `json:"letsencrypt"`
+
+	// Resolved during Validate — not user-facing
+	ContentDir        string `json:"-"`
+	ContentEntrypoint string `json:"-"`
 }
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		Port:              80,
-		ContentPath:       "/var/semdgo/content",
-		ContentEntrypoint: "README.md",
+		Port:        80,
+		ContentPath: "/var/semdgo/content",
 	}
 
 	data, err := os.ReadFile("semdgo.json")
@@ -45,9 +47,6 @@ func Load() (*Config, error) {
 	if cfg.ContentPath == "" {
 		cfg.ContentPath = "/var/semdgo/content"
 	}
-	if cfg.ContentEntrypoint == "" {
-		cfg.ContentEntrypoint = "README.md"
-	}
 
 	return cfg, nil
 }
@@ -60,16 +59,21 @@ func Validate(cfg *Config) error {
 		}
 		return fmt.Errorf("content_path %q: %w", cfg.ContentPath, err)
 	}
-	if !info.IsDir() {
-		return fmt.Errorf("content_path %q is not a directory", cfg.ContentPath)
+
+	if info.IsDir() {
+		cfg.ContentDir = cfg.ContentPath
+		cfg.ContentEntrypoint = "README.md"
+	} else {
+		cfg.ContentDir = filepath.Dir(cfg.ContentPath)
+		cfg.ContentEntrypoint = filepath.Base(cfg.ContentPath)
 	}
 
-	entrypoint := filepath.Join(cfg.ContentPath, cfg.ContentEntrypoint)
+	entrypoint := filepath.Join(cfg.ContentDir, cfg.ContentEntrypoint)
 	if _, err := os.Stat(entrypoint); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("content_entrypoint %q does not exist in %q", cfg.ContentEntrypoint, cfg.ContentPath)
+			return fmt.Errorf("entrypoint %q does not exist", entrypoint)
 		}
-		return fmt.Errorf("content_entrypoint %q: %w", entrypoint, err)
+		return fmt.Errorf("entrypoint %q: %w", entrypoint, err)
 	}
 
 	if cfg.LetsEncrypt.Enabled && cfg.LetsEncrypt.Domain == "" {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -11,9 +11,9 @@ import (
 	"github.com/shafinhasnat/semdgo/internal/utils"
 )
 
-func New(contentPath string) http.HandlerFunc {
+func New(contentPath, entrypoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		path := utils.ClickedHyperlink(r, contentPath)
+		path := utils.ClickedHyperlink(r, contentPath, entrypoint)
 		log.Printf("Status: %d | path: %s\n", http.StatusOK, path)
 		content, err := os.ReadFile(path)
 		if err != nil {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -11,26 +11,28 @@ import (
 	"github.com/shafinhasnat/semdgo/internal/utils"
 )
 
-func Handle(w http.ResponseWriter, r *http.Request) {
-	path := utils.ClickedHyperlink(r)
-	log.Printf("Status: %d | path: %s\n", http.StatusOK, path)
-	content, err := os.ReadFile(path)
-	if err != nil {
-		log.Printf("Status: %d | path: %s | Error: %s\n", http.StatusNotFound, path, err)
-		http.Error(w, "Unable to read markdown file", http.StatusNotFound)
-		return
+func New(contentPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		path := utils.ClickedHyperlink(r, contentPath)
+		log.Printf("Status: %d | path: %s\n", http.StatusOK, path)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("Status: %d | path: %s | Error: %s\n", http.StatusNotFound, path, err)
+			http.Error(w, "Unable to read markdown file", http.StatusNotFound)
+			return
+		}
+		if !strings.HasSuffix(path, ".md") {
+			http.ServeFile(w, r, path)
+			return
+		}
+		html := renderer.MDtoHTML(content)
+		tmpl, err := template.ParseFiles("./templates/200")
+		if err != nil {
+			panic(err)
+		}
+		tmpl.Execute(w, map[string]interface{}{
+			"Content": string(html),
+			"Path":    strings.TrimPrefix(path, contentPath),
+		})
 	}
-	if !strings.HasSuffix(path, ".md") {
-		http.ServeFile(w, r, path)
-		return
-	}
-	html := renderer.MDtoHTML(content)
-	tmpl, err := template.ParseFiles("./templates/200")
-	if err != nil {
-		panic(err)
-	}
-	tmpl.Execute(w, map[string]interface{}{
-		"Content": string(html),
-		"Path":    strings.TrimPrefix(path, "/var/semdgo/content"),
-	})
 }

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -2,13 +2,10 @@ package utils
 
 import "net/http"
 
-func ClickedHyperlink(r *http.Request) string {
-	basepath := "/var/semdgo/content"
+func ClickedHyperlink(r *http.Request, basepath string) string {
 	link := r.URL.Path
 	if link == "/" {
-		path := basepath + "/README.md"
-		return path
+		return basepath + "/README.md"
 	}
-	path := basepath + link
-	return path
+	return basepath + link
 }

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,11 +1,14 @@
 package utils
 
-import "net/http"
+import (
+	"net/http"
+	"path/filepath"
+)
 
-func ClickedHyperlink(r *http.Request, basepath string) string {
+func ClickedHyperlink(r *http.Request, basepath, entrypoint string) string {
 	link := r.URL.Path
 	if link == "/" {
-		return basepath + "/README.md"
+		return filepath.Join(basepath, entrypoint)
 	}
-	return basepath + link
+	return filepath.Join(basepath, link)
 }


### PR DESCRIPTION
## Summary
This PR adds configuration file support and automatic HTTPS provisioning via Let's Encrypt to SEMDGO. Users can now customize the port and enable TLS certificate management without manual intervention.

## Key Changes
- **Configuration System**: Added `semdgo.json` configuration file support with sensible defaults (port 80, HTTP only)
- **Let's Encrypt Integration**: Implemented automatic TLS certificate provisioning and renewal via `golang.org/x/crypto/acme/autocert`
- **HTTP to HTTPS Redirect**: When Let's Encrypt is enabled, HTTP traffic on port 80 is automatically redirected to HTTPS on port 443
- **Certificate Caching**: Certificates are persisted at `/var/semdgo/certs` for reuse across container restarts
- **Updated Documentation**: Added configuration examples and Docker Compose templates for both HTTP and HTTPS deployments
- **Go Version Update**: Updated to Go 1.24.0 with toolchain 1.24.7

## Implementation Details
- The `config.Load()` function gracefully handles missing configuration files, defaulting to port 80 with HTTPS disabled
- Let's Encrypt validation requires the domain to be set and publicly reachable on ports 80 and 443
- The server runs an HTTP redirect handler on port 80 when HTTPS is enabled, allowing Let's Encrypt ACME challenges to work properly
- Configuration validation ensures required fields (domain) are present when Let's Encrypt is enabled

https://claude.ai/code/session_01DBxHs9Rgcy4TKWAS5HaJgZ